### PR TITLE
例外処理を実装

### DIFF
--- a/src/main/java/com/chapter9work/crudapi/controller/PrefecturalGovernmentController.java
+++ b/src/main/java/com/chapter9work/crudapi/controller/PrefecturalGovernmentController.java
@@ -2,15 +2,19 @@ package com.chapter9work.crudapi.controller;
 
 import com.chapter9work.crudapi.entity.PrefecturalGovernment;
 import com.chapter9work.crudapi.service.PrefecturalGovernmentService;
+import com.chapter9work.crudapi.service.ResourceNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.ZonedDateTime;
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 @RestController
 public class PrefecturalGovernmentController {
@@ -39,13 +43,22 @@ public class PrefecturalGovernmentController {
     //localhost:8080/prefecturalGovernments?postCode=060-8588 にアクセスするとDBに登録されている都道府県庁情報から
     //郵便番号が060-8588と一致する都道府県情報を取得する
     @GetMapping("/prefecturalGovernments")
-    public ResponseEntity<String> getprefecturalGovernmentsByPostCode(@RequestParam("postCode") String postCode) {
-
+    public String getprefecturalGovernmentsByPostCode(@RequestParam("postCode") String postCode) {
         // prefecturalGovernmentServiceを使用して、指定された郵便番号にある都道府県庁を取得
-        Optional<PrefecturalGovernment> prefecturalGovernment = prefecturalGovernmentService.findByPostCode(postCode);
+        PrefecturalGovernment prefecturalGovernment = prefecturalGovernmentService.findByPostCode(postCode);
+        return prefecturalGovernment.getName();
+    }
 
-        //都道府県庁が存在する場合はその名前を取得し、存在しない場合は空の配列を返す
-        String prefecturalGovernmentName = prefecturalGovernment.map(PrefecturalGovernment::getName).orElse("");
-        return ResponseEntity.ok(prefecturalGovernmentName);
+    //例外処理を実装
+    @ExceptionHandler(value = ResourceNotFoundException.class)
+    public ResponseEntity<Map<String, String>> handleNoResourceFound(
+            ResourceNotFoundException e, HttpServletRequest request) {
+        Map<String, String> body = Map.of(
+                "timestamp", ZonedDateTime.now().toString(),
+                "status", String.valueOf(HttpStatus.NOT_FOUND.value()),
+                "error", HttpStatus.NOT_FOUND.getReasonPhrase(),
+                "message", e.getMessage(),
+                "path", request.getRequestURI());
+        return new ResponseEntity(body, HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/com/chapter9work/crudapi/controller/PrefecturalGovernmentController.java
+++ b/src/main/java/com/chapter9work/crudapi/controller/PrefecturalGovernmentController.java
@@ -43,10 +43,10 @@ public class PrefecturalGovernmentController {
     //localhost:8080/prefecturalGovernments?postCode=060-8588 にアクセスするとDBに登録されている都道府県庁情報から
     //郵便番号が060-8588と一致する都道府県情報を取得する
     @GetMapping("/prefecturalGovernments")
-    public String getprefecturalGovernmentsByPostCode(@RequestParam("postCode") String postCode) {
+    public ResponseEntity<PrefecturalGovernment> getprefecturalGovernmentsByPostCode(@RequestParam("postCode") String postCode) {
         // prefecturalGovernmentServiceを使用して、指定された郵便番号にある都道府県庁を取得
         PrefecturalGovernment prefecturalGovernment = prefecturalGovernmentService.findByPostCode(postCode);
-        return prefecturalGovernment.getName();
+        return ResponseEntity.ok(prefecturalGovernment);
     }
 
     //例外処理を実装

--- a/src/main/java/com/chapter9work/crudapi/service/PrefecturalGovernmentService.java
+++ b/src/main/java/com/chapter9work/crudapi/service/PrefecturalGovernmentService.java
@@ -3,7 +3,6 @@ package com.chapter9work.crudapi.service;
 import com.chapter9work.crudapi.entity.PrefecturalGovernment;
 
 import java.util.List;
-import java.util.Optional;
 
 // PrefecturalGovernmentServiceインターフェース: 都道府県庁関連のデータを操作するためのメソッドを定義
 public interface PrefecturalGovernmentService {
@@ -12,5 +11,5 @@ public interface PrefecturalGovernmentService {
     List<PrefecturalGovernment> findAll();
 
     //指定された郵便番号の都道府県庁の情報を取得するメソッド
-    Optional<PrefecturalGovernment> findByPostCode(String postCode);
+    PrefecturalGovernment findByPostCode(String postCode);
 }

--- a/src/main/java/com/chapter9work/crudapi/service/PrefecturalGovernmentServiceImpl.java
+++ b/src/main/java/com/chapter9work/crudapi/service/PrefecturalGovernmentServiceImpl.java
@@ -26,10 +26,15 @@ public class PrefecturalGovernmentServiceImpl implements PrefecturalGovernmentSe
         return prefecturalGovernmentMapper.findAll(); // Mapperを使用してデータベースから都道府県情報を取得
     }
 
-    // 指定された郵便番号の都道府県庁情報を取得するメソッド
+    // 指定された郵便番号の都道府県庁情報を取得するメソッド(もし都道府県情報が存在しない場合は"resource not found"を返す)
     @Override
-    public Optional<PrefecturalGovernment> findByPostCode(String postCode) {
-        return prefecturalGovernmentMapper.findByPostCode(postCode);  // Mapperを使用して指定された年の都道府県情報を取得
+    public PrefecturalGovernment findByPostCode(String postCode) {
+        Optional<PrefecturalGovernment> prefecturalGovernment = this.prefecturalGovernmentMapper.findByPostCode(postCode);
+        if (prefecturalGovernment.isPresent()) {
+            return prefecturalGovernment.get();
+        } else {
+            throw new ResourceNotFoundException("resource not found");
+        }
     }
-    
+
 }

--- a/src/main/java/com/chapter9work/crudapi/service/ResourceNotFoundException.java
+++ b/src/main/java/com/chapter9work/crudapi/service/ResourceNotFoundException.java
@@ -1,0 +1,16 @@
+package com.chapter9work.crudapi.service;
+
+public class ResourceNotFoundException extends RuntimeException {
+    public ResourceNotFoundException() {
+        super();
+    }
+    public ResourceNotFoundException(String message, Throwable cause) {
+        super(message, cause);
+    }
+    public ResourceNotFoundException(String message) {
+        super(message);
+    }
+    public ResourceNotFoundException(Throwable cause) {
+        super(cause);
+    }
+}


### PR DESCRIPTION
## 概要
データベースに登録されていない郵便番号をリクエストした場合に404を返す例外処理を実装しました。
## 動作確認
- 成功パターン
<img width="1031" alt="スクリーンショット 2023-09-18 14 30 15" src="https://github.com/k-prog55/chapter9/assets/138343132/7f7cd1f5-2342-4bac-9e35-7b684bdb993b">


- 失敗パターン
<img width="1053" alt="スクリーンショット 2023-09-18 13 50 37" src="https://github.com/k-prog55/chapter9/assets/138343132/8c26947b-0e64-4f15-99b5-6d1cc2f601eb">
